### PR TITLE
RRI bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,12 @@ is_system_service: False</pre>
 NOTE: You must perform step #1 at least once or Moonraker will generate an error.
 
 ### 4. Modify "start_print" macro in your printer.cfg
-- Modify your "print_start" macro in your printer.cfg to include the 2 parameters (PRINT_MIN and PRINT_MAX) <pre>
-[gcode_macro print_start]
-variable_parameter_PRINT_MIN : 0,0
-variable_parameter_PRINT_MAX : 0,0
-gcode:
-</pre>
-
 - Where you normally perform a BED_MESH_CALIBRATE in your start_print macro, replace it (or add it if you didn't previously have it) with the following line:<pre>
 BED_MESH_CALIBRATE PRINT_MIN={params.PRINT_MIN} PRINT_MAX={params.PRINT_MAX}
+</pre>
+
+- If you want to force a new mesh every time, use the following syntax:<pre>
+BED_MESH_CALIBRATE PRINT_MIN={params.PRINT_MIN} PRINT_MAX={params.PRINT_MAX} FORCE_NEW_MESH=True
 </pre>
 
 ### 5. Update your Slicer
@@ -64,10 +61,10 @@ BED_MESH_CALIBRATE PRINT_MIN={params.PRINT_MIN} PRINT_MAX={params.PRINT_MAX}
 Examples:
 
 
-PrusaSlicer/SuperSlicer:
+- PrusaSlicer/SuperSlicer:
 <pre>print_start EXTRUDER={first_layer_temperature[initial_extruder] + extruder_temperature_offset[initial_extruder]} BED=[first_layer_bed_temperature] CHAMBER=[chamber_temperature] PRINT_MIN={first_layer_print_min[0]},{first_layer_print_min[1]} PRINT_MAX={first_layer_print_max[0]},{first_layer_print_max[1]}</pre>
 
-Cura (add this to your start gcofe at the end of the start_print command:)
+- Cura (add this to your start gcode at the end of the start_print command:)
 <pre>PRINT_MIN=%MINX%,%MINY% PRINT_MAX=%MAXX%,%MAXY%</pre>
 
 *(Cura slicer plugin) To make the macro to work in Cura slicer, you need to install the post process plugin by frankbags - In cura menu Help -> Show configuration folder. - Copy the python script from the above link in to plugins folder. - Restart Cura - In cura menu Extensions -> Post processing and select Mesh Print Size

--- a/print_area_bed_mesh.cfg
+++ b/print_area_bed_mesh.cfg
@@ -114,7 +114,7 @@ gcode:
                 SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=last_area_end_x VALUE={print_max_x}
                 SET_GCODE_VARIABLE MACRO=BED_MESH_CALIBRATE VARIABLE=last_area_end_y VALUE={print_max_y}
 
-                {% if (relative_reference_index == 0) %}
+                {% if relative_reference_index == NULL %}
                     _BED_MESH_CALIBRATE mesh_min={mesh_min_x},{mesh_min_y} mesh_max={mesh_max_x},{mesh_max_y} probe_count={probe_count_x},{probe_count_y}
                 {% else %}
                     {% set relative_reference_index = ((probe_count_x * probe_count_y - 1) / 2)|int %}

--- a/print_area_bed_mesh.cfg
+++ b/print_area_bed_mesh.cfg
@@ -56,7 +56,7 @@ gcode:
         {% if (params.FORCE_NEW_MESH != null) or (print_min_x < last_area_start_x) or (print_max_x > last_area_end_x) or (print_min_y < last_area_start_y) or (print_max_y > last_area_end_y)  %}
             {% if klicky_available %}
                 _CheckProbe action=query
-                ATTACH_PROBE_LOCK
+                ATTACH_PROBE
             {% endif %}
             {% if (print_min_x < print_max_x) and (print_min_y < print_max_y) %}
 
@@ -133,7 +133,7 @@ gcode:
                 _BED_MESH_CALIBRATE
             {% endif %}
             {% if klicky_available %}
-                DOCK_PROBE_UNLOCK
+                DOCK_PROBE
             {% endif %}
         {% else %}
             { action_respond_info("No need to recreate Bed Mesh since it's same as current mesh or smaller") }
@@ -141,14 +141,14 @@ gcode:
     {% else %}
         {% if klicky_available %}
             _CheckProbe action=query
-            ATTACH_PROBE_LOCK
+            ATTACH_PROBE
         {% endif %}
         {% if printer["gcode_macro status_meshing"] != null %}
             status_meshing
         {% endif %}
         _BED_MESH_CALIBRATE
         {% if klicky_available %}
-            DOCK_PROBE_UNLOCK
+            DOCK_PROBE
         {% endif %}
     {% endif %}
     {% if printer["gcode_macro status_ready"] != null %}

--- a/print_area_bed_mesh.cfg
+++ b/print_area_bed_mesh.cfg
@@ -119,7 +119,7 @@ gcode:
                     status_meshing
                 {% endif %}
 
-                {% if (relative_reference_index == 0) %}
+                {% if relative_reference_index == NULL %}
                     _BED_MESH_CALIBRATE mesh_min={mesh_min_x},{mesh_min_y} mesh_max={mesh_max_x},{mesh_max_y} probe_count={probe_count_x},{probe_count_y}
                 {% else %}
                     {% set relative_reference_index = ((probe_count_x * probe_count_y - 1) / 2)|int %}

--- a/print_area_bed_mesh.cfg
+++ b/print_area_bed_mesh.cfg
@@ -55,7 +55,7 @@ gcode:
         {% if (params.FORCE_NEW_MESH != null) or (print_min_x < last_area_start_x) or (print_max_x > last_area_end_x) or (print_min_y < last_area_start_y) or (print_max_y > last_area_end_y)  %}
             {% if klicky_available %}
                 _CheckProbe action=query
-                Attach_Probe
+                ATTACH_PROBE_LOCK
             {% endif %}
             {% if (print_min_x < print_max_x) and (print_min_y < print_max_y) %}
 
@@ -125,7 +125,7 @@ gcode:
                 _BED_MESH_CALIBRATE
             {% endif %}
             {% if klicky_available %}
-                Dock_Probe
+                DOCK_PROBE_UNLOCK
             {% endif %}
         {% else %}
             { action_respond_info("No need to recreate Bed Mesh since it's same as current mesh or smaller") }
@@ -133,10 +133,10 @@ gcode:
     {% else %}
         {% if klicky_available %}
             _CheckProbe action=query
-            Attach_Probe
+            ATTACH_PROBE_LOCK
         {% endif %}
         _BED_MESH_CALIBRATE
         {% if klicky_available %}
-            Dock_Probe
+            DOCK_PROBE_UNLOCK
         {% endif %}
     {% endif %}


### PR DESCRIPTION
fixed RRI bug
"0" is an index number it needs to be NULL
cleaned code a little to keep naming convention of other macros.

not defining RRI in the printer.config file defaults it to "NULL"
from my tests it looks like using RRI is not a good idea due to the constant mesh size changing 

snipit from klipper code defining relative_reference_index to "none"/null
![Code_kXX5Fd8GJA](https://user-images.githubusercontent.com/40685552/149622703-7da4cd84-1d1d-4ac4-b99c-9a35b6ddef60.png)

no RRI, grid size 9x9 
![NO_RRI](https://user-images.githubusercontent.com/40685552/149622786-10994c7f-8570-4ddf-a25c-664a47c6d8c4.jpg)

RRI 40 grid zie 9x9
![RRI_40](https://user-images.githubusercontent.com/40685552/149622788-170ca78a-1bfe-43bb-b267-20c9edbc6091.jpg)

