### PR TITLE
Update print_area_bed_mesh.cfg

### DIFF
--- a/print_area_bed_mesh.cfg
+++ b/print_area_bed_mesh.cfg
@@ -28,6 +28,7 @@ gcode:
     {% endif %}
 
     {% set klicky_available = printer['gcode_macro _Probe_Variables'] != null %}
+    {% set euclid_available = printer['gcode_macro EuclidProbe'] != null %}; Requires v5 macros https://github.com/nionio6915/Euclid_Probe/blob/main/Firmware_Examples/Klipper/00-euclid_exampleV5.cfg
     {% if params.PRINT_MIN %}
         { action_respond_info("print_min: %s" % params.PRINT_MIN) }
         { action_respond_info("print_max: %s" % params.PRINT_MAX) }
@@ -57,6 +58,8 @@ gcode:
             {% if klicky_available %}
                 _CheckProbe action=query
                 Attach_Probe
+            {% elif euclid_available %}
+                DEPLOY_PROBE
             {% endif %}
             {% if (print_min_x < print_max_x) and (print_min_y < print_max_y) %}
 
@@ -134,6 +137,8 @@ gcode:
             {% endif %}
             {% if klicky_available %}
                 Dock_Probe
+            {% elif euclid_available %}
+                STOW_PROBE
             {% endif %}
         {% else %}
             { action_respond_info("No need to recreate Bed Mesh since it's same as current mesh or smaller") }
@@ -142,6 +147,8 @@ gcode:
         {% if klicky_available %}
             _CheckProbe action=query
             Attach_Probe
+        {% elif euclid_available %}
+            STOW_PROBE
         {% endif %}
         {% if printer["gcode_macro status_meshing"] != null %}
             status_meshing
@@ -149,6 +156,9 @@ gcode:
         _BED_MESH_CALIBRATE
         {% if klicky_available %}
             Dock_Probe
+        {% endif %}
+        {% if euclid_available %}
+            STOW_PROBE
         {% endif %}
     {% endif %}
     {% if printer["gcode_macro status_ready"] != null %}


### PR DESCRIPTION
Added additional checks when using a Euclid probe.

Currently the script checks for the presence of a Klicky probe by looking for the "_Probe_Variables" macro. Euclid doesn't use this macro so the script doesn't attach the Euclid probe and meshing fails.

New check added to look for the "EuclidProbe" macro which is defined when using a Euclid probe. 

You need to be using v5 of the Euclid macros (https://github.com/nionio6915/Euclid_Probe/blob/main/Firmware_Examples/Klipper/00-euclid_exampleV5.cfg) so that the probe is deployed and stowed with the "DEPLOY_PROBE" and "STOW_PROBE" macros, which were M401 and M402 in earlier versions of Euclid Macros.

Tested as working on a Voron V2.4.